### PR TITLE
throw Error if file not found

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as ts from 'typescript';
+import * as fs from 'fs';
 import {dirname} from 'path';
 
 function handleDiagnostics(
@@ -93,6 +94,10 @@ export function check(
   const allErrors: string[] = [];
 
   for (const file of files) {
+    if (!fs.existsSync(file)) {
+      throw new Error(`File '${file}' not found.`);
+    }
+
     const program = ts.createProgram([file], options);
 
     const global = handleDiagnostics(

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,27 +1,45 @@
-import test = require("tape");
+import test = require('tape');
 import {check, checkDirectory} from '../src/index';
-import {join} from "path";
-
+import {join} from 'path';
 
 test('check', assert => {
+  assert.throws(() => {
+    check(
+      [join(__dirname, 'failing/expected.ts')],
+      join(__dirname, 'notfound/tsconfig.json'),
+    );
+  }, /path does not exist/);
+
+  assert.throws(() => {
+    check(
+      [join(__dirname, 'failing/notfound.ts')],
+      join(__dirname, 'failing/tsconfig.json'),
+    );
+  }, /File.*not found/);
+
   assert.doesNotThrow(() => {
-    check([join(__dirname, 'files/test.ts')],
-      join(__dirname, 'files/tsconfig.json'));
+    check(
+      [join(__dirname, 'files/test.ts')],
+      join(__dirname, 'files/tsconfig.json'),
+    );
   });
 
   assert.throws(() => {
-    check([join(__dirname, 'failing/expected.ts')],
-      join(__dirname, 'failing/tsconfig.json'));
+    check(
+      [join(__dirname, 'failing/expected.ts')],
+      join(__dirname, 'failing/tsconfig.json'),
+    );
   }, /Expected error:.*\(2, 1\)/);
 
   assert.throws(() => {
-    check([join(__dirname, 'failing/unexpected.ts')],
-      join(__dirname, 'failing/tsconfig.json'));
+    check(
+      [join(__dirname, 'failing/unexpected.ts')],
+      join(__dirname, 'failing/tsconfig.json'),
+    );
   }, /Semantic:.*\(2, 9\)/);
 
   assert.end();
 });
-
 
 test('checkDirectory', assert => {
   assert.doesNotThrow(() => {


### PR DESCRIPTION
No exception was being thrown when a specified `.ts` file was not found. This PR throws the exception. It includes tests for `.ts` file not found and `tsconfig.json` not found.

The Typescript compiler does of course detect that the `.ts` was not found, and it reports it in diagnostics. I spent more time than I should have trying to figure out how to pull the error out of diagnostics without also pulling out the errors that would be handled in later code.

So I opted to just throw an `fs.existsSync(file)` in there. Easy peasy, done.

Thanks for this awesome tool. I can't believe that its use isn't mandatory for all typings!