### PR TITLE
Normalize path for Windows 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as ts from 'typescript';
 import * as fs from 'fs';
-import {dirname} from 'path';
+import {dirname, normalize} from 'path';
 
 function handleDiagnostics(
   type: string,
@@ -116,7 +116,9 @@ export function check(
     for (const sourceFile of program.getSourceFiles()) {
       let semantic = program.getSemanticDiagnostics(sourceFile);
 
-      if (program.getRootFileNames().indexOf(sourceFile.fileName) !== -1) {
+      const rootFileNames = program.getRootFileNames().map(normalize);
+      const fileName = normalize(sourceFile.fileName);
+      if (rootFileNames.indexOf(fileName) !== -1) {
         forEachExpectedFailureNodes(sourceFile, node => {
           const failures: ts.Diagnostic[] = [];
           const leftSemantics: ts.Diagnostic[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,5 +163,9 @@ export function checkDirectory(path: string, bail: boolean = false) {
   const files = ts.sys.readDirectory(path, ['.ts', '.tsx']);
   const tsConfigPath = ts.findConfigFile(path, ts.sys.fileExists);
 
+  if (!tsConfigPath) {
+    throw new Error(`Cannot find TypeScript config file in ${path}.`);
+  }
+
   check(files, tsConfigPath, bail);
 }


### PR DESCRIPTION
The original tests don't seem to work on my Windows 10 + TypeScript 2.9.2. 